### PR TITLE
Copy to Clipboard copies extra column

### DIFF
--- a/frontend/src/views/queries/components/CopyToClipboardFromTableBody.js
+++ b/frontend/src/views/queries/components/CopyToClipboardFromTableBody.js
@@ -5,7 +5,8 @@ export default function CopyToClipboardFromTableBody(tables) {
   for (let x = 0; x < tables.length; x++) {
     for (let i = 0; i < tables[x].rows.length; i++) {
       for (let j = 0; j < tables[x].rows[i].cells.length; j++) {
-        text += `${tables[x].rows[i].cells[j].innerText}\t`
+        text += `${tables[x].rows[i].cells[j].innerText}`
+        text += j + 1 === tables[x].rows[i].cells.length ? '' : '\t'
       }
       text += '\n'
     }


### PR DESCRIPTION
## Copy to Clipboard copies extra column
[Ticket](https://app.asana.com/0/1177918520488616/1182273191656689/f)
- [x] QA @userlab-josuesosa 
- [ ] CR @userlab-cesarsalazar 

## What changed?
- now it only adds \t when the end of the row is not reached yet